### PR TITLE
define Security policy in github repository

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,4 @@
+# Security Policy
+
+Security issues should be resposibly disclosed through the official __[Bug Bounty program](https://www.synapsec.ai/bug-bounty)__ .
+


### PR DESCRIPTION
This will make it much easier for developers to find where they should report **Security** issues by levering github user interface.

![image](https://github.com/synapsec-ai/llm-defender-subnet/assets/122983254/d8e12c6d-081a-4746-9698-862a22efde04)
the `SECURITY.md` will be shown in github repository view under Security link

You can read more about this github feature here: https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository