### PR TITLE
Add fields for notification synapse

### DIFF
--- a/llm_defender/base/protocol.py
+++ b/llm_defender/base/protocol.py
@@ -14,23 +14,23 @@ class LLMDefenderProtocol(bt.Synapse):
     """
 
     # Parse variables
-    output: typing.Optional[dict] = None
+    output: dict | None = None
 
     synapse_uuid: str = pydantic.Field(
         ...,
-        description="Synapse UUID provides an unique identifier for the prompt send out by the validator",
+        description="Synapse UUID provides a unique identifier for the prompt sent out by the validator",
         allow_mutation=False
     )
 
     synapse_nonce: str = pydantic.Field(
         ...,
-        description="Synapse nonce provides an unique identifier for the prompt send out by the validator",
+        description="Synapse nonce provides a unique identifier for the prompt sent out by the validator",
         allow_mutation=False
     )
 
     synapse_timestamp: str = pydantic.Field(
         ...,
-        description="Synapse timestamp provides an unique identifier for the prompt send out by the validator",
+        description="Synapse timestamp provides a unique identifier for the prompt sent out by the validator",
         allow_mutation=False
     )
 
@@ -40,8 +40,8 @@ class LLMDefenderProtocol(bt.Synapse):
         allow_mutation=False,
     )
 
-    analyzer: str = pydantic.Field(
-        ...,
+    analyzer: str | None = pydantic.Field(
+        None,
         title="analyzer",
         description="The analyzer field provides instructions on which Analyzer to execute on the miner",
         allow_mutation=False,
@@ -51,6 +51,20 @@ class LLMDefenderProtocol(bt.Synapse):
         ...,
         title="synapse_signature",
         description="The synapse_signature field provides the miner means to validate the origin of the Synapse",
+        allow_mutation=False,
+    )
+
+    synapse_prompt: str | None = pydantic.Field(
+        None,
+        title="synapse_prompt",
+        description="Optional field providing additional prompt information.",
+        allow_mutation=False,
+    )
+
+    synapse_hash: str | None = pydantic.Field(
+        None,
+        title="synapse_hash",
+        description="Optional field providing hash information for the synapse.",
         allow_mutation=False,
     )
 

--- a/tests/base/test_protocol.py
+++ b/tests/base/test_protocol.py
@@ -1,0 +1,116 @@
+import pytest
+
+from llm_defender.base.protocol import LLMDefenderProtocol
+
+
+@pytest.fixture
+def sample_protocol_instance():
+    return LLMDefenderProtocol(
+        output={"result": "sample_output"},
+        synapse_uuid="sample_uuid",
+        synapse_nonce="sample_nonce",
+        synapse_timestamp="sample_timestamp",
+        subnet_version=1,
+        analyzer="sample_analyzer",
+        synapse_signature="sample_signature",
+        synapse_prompt="sample_prompt",
+        synapse_hash="sample_hash"
+    )
+
+
+@pytest.fixture
+def instance_with_null_values():
+    return LLMDefenderProtocol(
+        output=None,
+        synapse_uuid="sample_uuid",
+        synapse_nonce="sample_nonce",
+        synapse_timestamp="sample_timestamp",
+        subnet_version=1,
+        analyzer=None,
+        synapse_signature="sample_signature",
+        synapse_prompt=None,
+        synapse_hash=None
+    )
+
+
+def test_deserialize(sample_protocol_instance):
+    deserialized_instance = sample_protocol_instance.deserialize()
+    assert isinstance(deserialized_instance, LLMDefenderProtocol)
+    assert deserialized_instance == sample_protocol_instance
+
+
+def test_nullable_fields_with_values(sample_protocol_instance):
+    assert isinstance(sample_protocol_instance.output, (dict, type(None)))
+    assert isinstance(sample_protocol_instance.analyzer, (str, type(None)))
+    assert isinstance(sample_protocol_instance.synapse_prompt, (str, type(None)))
+    assert isinstance(sample_protocol_instance.synapse_hash, (str, type(None)))
+
+
+def test_synapse_uuid_required():
+    with pytest.raises(ValueError):
+        LLMDefenderProtocol(
+            output={"result": "sample_output"},
+            synapse_nonce="sample_nonce",
+            synapse_timestamp="sample_timestamp",
+            subnet_version=1,
+            analyzer="sample_analyzer",
+            synapse_signature="sample_signature",
+            synapse_prompt="sample_prompt",
+            synapse_hash="sample_hash"
+        )
+
+
+def test_synapse_nonce_required():
+    with pytest.raises(ValueError):
+        LLMDefenderProtocol(
+            synapse_uuid="sample_uuid",
+            synapse_timestamp="sample_timestamp",
+            subnet_version=1,
+            analyzer="sample_analyzer",
+            synapse_signature="sample_signature",
+            synapse_prompt="sample_prompt",
+            synapse_hash="sample_hash"
+        )
+
+
+def test_synapse_timestamp_required():
+    with pytest.raises(ValueError):
+        LLMDefenderProtocol(
+            synapse_uuid="sample_uuid",
+            subnet_version=1,
+            analyzer="sample_analyzer",
+            synapse_signature="sample_signature",
+            synapse_prompt="sample_prompt",
+            synapse_hash="sample_hash"
+        )
+
+
+def test_subnet_version_required():
+    with pytest.raises(ValueError):
+        LLMDefenderProtocol(
+            synapse_uuid="sample_uuid",
+            synapse_timestamp="sample_timestamp",
+            analyzer="sample_analyzer",
+            synapse_signature="sample_signature",
+            synapse_prompt="sample_prompt",
+            synapse_hash="sample_hash"
+        )
+
+
+def test_synapse_signature_required():
+    with pytest.raises(ValueError):
+        LLMDefenderProtocol(
+            synapse_uuid="sample_uuid",
+            synapse_timestamp="sample_timestamp",
+            subnet_version=1,
+            analyzer="sample_analyzer",
+            synapse_prompt="sample_prompt",
+            synapse_hash="sample_hash"
+        )
+
+
+def test_optional_fields_not_provided(instance_with_null_values):
+    assert instance_with_null_values.output is None
+    assert instance_with_null_values.analyzer is None
+    assert instance_with_null_values.synapse_prompt is None
+    assert instance_with_null_values.synapse_hash is None


### PR DESCRIPTION
- Adding `synapse_prompt`, and `synapse_hash`
- Change `analyzer` field to be nullable
- Update null support syntax in pydantic
- Fixing typos in doc strings
- Add unit tests for `LLMDefenderProtocol`