### PR TITLE
Fetch API decommission - validator and miner changes

### DIFF
--- a/docker-compose-local-dev.yml
+++ b/docker-compose-local-dev.yml
@@ -1,0 +1,56 @@
+version: '3'
+services:
+  validator1:
+    image: llm-defender-subnet
+    build:
+      context: .
+      dockerfile: Dockerfile   
+    command: /bin/bash -c "source /tmp/.venv/bin/activate && pip install -e ${VALIDATOR_PIP_INSTALL_PATH} && ls -la /var/run/llm-defender-subnet/ && ls -la /var/run/llm-defender-subnet/llm_defender && python3 /var/run/llm-defender-subnet/llm_defender/neurons/validator.py --netuid ${NETUID} --subtensor.network ${SUBTENSOR_NETWORK} --wallet.path ${WALLET_PATH} --wallet.name ${VALIDATOR_WALLET} --wallet.hotkey ${VALIDATOR_HOTKEY} --logging.debug"
+    volumes:
+      - .:/var/run/llm-defender-subnet
+    networks:
+      llm-defender-subnet-network-development:
+        ipv4_address: ${VALIDATOR_IP}
+  
+  # validator2:
+  #   image: llm-defender-subnet
+  #   build:
+  #     context: .
+  #     dockerfile: Dockerfile   
+  #   command: /bin/bash -c "source /tmp/.venv/bin/activate && pip install -e ${VALIDATOR_PIP_INSTALL_PATH} && python3 /var/run/llm-defender-subnet/llm_defender/neurons/validator.py --netuid ${NETUID} --subtensor.network ${SUBTENSOR_NETWORK} --wallet.path ${WALLET_PATH} --wallet.name ${VALIDATOR2_WALLET} --wallet.hotkey ${VALIDATOR2_HOTKEY} --logging.debug"
+  #   volumes:
+  #     - .:/var/run/llm-defender-subnet
+  #   networks:
+  #     llm-defender-subnet-network-development:
+  #       ipv4_address: ${VALIDATOR2_IP}
+
+  miner1:
+    image: llm-defender-subnet
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: /bin/bash -c "source /tmp/.venv/bin/activate && pip install -e ${MINER_PIP_INSTALL_PATH} && pip uninstall -y uvloop && python3 /var/run/llm-defender-subnet/llm_defender/neurons/miner.py --netuid ${NETUID} --subtensor.network ${SUBTENSOR_NETWORK} --wallet.path ${WALLET_PATH} --wallet.name ${MINER_WALLET} --wallet.hotkey ${MINER_HOTKEY} --axon.port ${MINER_PORT} --validator_min_stake 0 --axon.external_ip ${MINER_IP} --logging.debug"
+    volumes:
+      - .:/var/run/llm-defender-subnet
+    networks:
+      llm-defender-subnet-network-development:
+        ipv4_address: ${MINER_IP}
+  miner2:
+    image: llm-defender-subnet
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: /bin/bash -c "source /tmp/.venv/bin/activate && pip install -e ${MINER_PIP_INSTALL_PATH} && pip uninstall -y uvloop && python3 /var/run/llm-defender-subnet/llm_defender/neurons/miner.py --netuid ${NETUID} --subtensor.network ${SUBTENSOR_NETWORK} --wallet.path ${WALLET_PATH} --wallet.name ${MINER2_WALLET} --wallet.hotkey ${MINER2_HOTKEY} --axon.port ${MINER2_PORT} --validator_min_stake 0 --axon.external_ip ${MINER2_IP} --logging.debug"
+    volumes:
+      - .bittensor:/tmp/.bittensor
+    networks:
+      llm-defender-subnet-network-development:
+        ipv4_address: ${MINER2_IP}
+
+networks:
+  llm-defender-subnet-network-development:
+    driver: bridge
+    ipam:
+     config:
+       - subnet: ${DOCKER_NETWORK_SUBNET}
+         gateway: ${DOCKER_NETWORK_GATEWAY}

--- a/llm_defender/core/miners/miner.py
+++ b/llm_defender/core/miners/miner.py
@@ -168,27 +168,7 @@ class LLMDefenderMiner(BaseNeuron):
         bt.logging.info(f"Miner is running with UID: {miner_uid}")
 
         return wallet, subtensor, metagraph, miner_uid
-    
-    def get_prompt_from_api(self, hotkey, signature, synapse_uuid, timestamp, nonce, validator_hotkey) -> dict:
-        """Retrieves a prompt from the prompt API"""
 
-        headers = {
-            "X-Hotkey": hotkey,
-            "X-Signature": signature,
-            "X-SynapseUUID": synapse_uuid,
-            "X-Timestamp": timestamp,
-            "X-Nonce": nonce,
-            "X-Version": str(self.subnet_version),
-            "X-API-Key": hotkey,
-            "X-ValidatorHotkey": validator_hotkey
-        }
-
-        res = self.requests_post(url="https://fetch-api.synapsec.ai/fetch", headers=headers, data={}, timeout=12)
-        
-        if res and "prompt" in res.keys():
-            bt.logging.trace(f"Obtained response from prompt API: {res}")
-            return res["prompt"]
-        return None
 
     def check_whitelist(self, hotkey):
         """

--- a/llm_defender/core/validators/validator.py
+++ b/llm_defender/core/validators/validator.py
@@ -57,7 +57,7 @@ class LLMDefenderValidator(BaseNeuron):
         self.wallet = None
         self.subtensor = None
         self.dendrite = None
-        self.metagraph = None
+        self.metagraph: bt.metagraph | None = None
         self.scores = None
         self.hotkeys = None
         self.miner_responses = None
@@ -596,12 +596,7 @@ class LLMDefenderValidator(BaseNeuron):
             dtype=torch.bool,
         )
         bt.logging.trace(f"UIDs with 0.0.0.0 as an IP address: {invalid_uids}")
-
-        # Determine the UIDs to filter
-        uids_to_filter = torch.logical_not(
-            ~invalid_uids | ~uids_with_stake
-        )
-
+        uids_to_filter = torch.logical_and(invalid_uids, uids_with_stake)
         bt.logging.trace(f"UIDs to filter: {uids_to_filter}")
 
         # Define UIDs to query

--- a/llm_defender/core/validators/validator.py
+++ b/llm_defender/core/validators/validator.py
@@ -398,6 +398,8 @@ class LLMDefenderValidator(BaseNeuron):
 
         return self.prompt
 
+    async def serve_prompt_async(self, synapse_uuid, miner_hotkeys):
+        return await asyncio.to_thread(self.serve_prompt, synapse_uuid, miner_hotkeys)
 
     def check_hotkeys(self):
         """Checks if some hotkeys have been replaced in the metagraph"""

--- a/llm_defender/core/validators/validator.py
+++ b/llm_defender/core/validators/validator.py
@@ -398,7 +398,7 @@ class LLMDefenderValidator(BaseNeuron):
 
         return self.prompt
 
-    async def serve_prompt_async(self, synapse_uuid, miner_hotkeys):
+    async def load_prompt_to_validator_async(self, synapse_uuid, miner_hotkeys):
         return await asyncio.to_thread(self.serve_prompt, synapse_uuid, miner_hotkeys)
 
     def check_hotkeys(self):

--- a/llm_defender/neurons/validator.py
+++ b/llm_defender/neurons/validator.py
@@ -145,7 +145,7 @@ async def send_notification_message_async(synapse_uuid, validator, axons_with_va
             synapse_signature=utils.sign_data(hotkey=validator.wallet.hotkey, data=data_to_sign),
             synapse_nonce=nonce,
             synapse_timestamp=timestamp,
-            prompt_hash=prompt_hash
+            synapse_hash=prompt_hash
         ),
         timeout=validator.timeout,
         deserialize=True,


### PR DESCRIPTION
Changes to delete the fetch api calls.
- Handle notification messages
- Handle payload messages
- Remove `get_prompt_from_api` method